### PR TITLE
Fix integer overflow on indices

### DIFF
--- a/src/flash_internal.h
+++ b/src/flash_internal.h
@@ -1,5 +1,5 @@
 struct Qkv_params {
-    using index_t = uint32_t;
+    using index_t = int64_t;
     // The QKV matrices.
     void *__restrict__ q_ptr;
     void *__restrict__ k_ptr;


### PR DESCRIPTION
Turns out this is necessary to run Flash-Decoding on realistic workloads. The upstream has this change but it was made just last week... https://github.com/Dao-AILab/flash-attention/commit/000b67f5d866413565573cd57e6e4491e2da6f4f