### PR TITLE
Set `params.is_causal` based on `window_size`, not from user param

### DIFF
--- a/src/flash.cu
+++ b/src/flash.cu
@@ -96,7 +96,9 @@ void flash_attention_forward(half* q_ptr,
   params.k_ptr = k_ptr;
   params.v_ptr = v_ptr;
   params.o_ptr = output_ptr;
-  params.is_causal = is_causal;
+  // Causal is the special case where window_size_right == 0 and window_size_left < 0.
+  // Local is the more general case where window_size_right >= 0 or window_size_left >= 0.
+  params.is_causal = window_size_left < 0 && window_size_right == 0;
   params.b = batch_size;
   params.h = num_heads;
   params.h_k = num_heads_k;
@@ -176,7 +178,9 @@ void flash_attention_var_len_forward(half *q_ptr,
   params.cu_seqlens_q = cu_seqlens_q;
   params.cu_seqlens_k = cu_seqlens_k;
   params.o_ptr = output_ptr;
-  params.is_causal = is_causal;
+  // Causal is the special case where window_size_right == 0 and window_size_left < 0.
+  // Local is the more general case where window_size_right >= 0 or window_size_left >= 0.
+  params.is_causal = window_size_left < 0 && window_size_right == 0;
   params.b = batch_size;
   params.h = num_heads;
   params.h_k = num_heads_k;
@@ -324,7 +328,9 @@ void flash_attention_splitkv_paged_forward(half* q_ptr,
   params.k_ptr = kcache_ptr;
   params.v_ptr = vcache_ptr;
   params.o_ptr = output_ptr;
-  params.is_causal = is_causal;
+  // Causal is the special case where window_size_right == 0 and window_size_left < 0.
+  // Local is the more general case where window_size_right >= 0 or window_size_left >= 0.
+  params.is_causal = window_size_left < 0 && window_size_right == 0;
   params.b = batch_size;
   params.h = num_heads;
   params.h_k = num_heads_k;


### PR DESCRIPTION
https://github.com/tlc-pack/libflash_attn/pull/9 introduced a bug which affects when
* Model uses sliding window
* The input context is less than `window_size`

Flash attention introduced an optimization https://github.com/Dao-AILab/flash-attention/commit/0842ec0da46da6da098410cf149208b548f03e24 where the sliding-window kernel is disabled when the context length is less than the window size. In such case, we are supposed to be doing a normal causal attention, but due to how TVM BYOC sets `is_causal` param in https://github.com/apache/tvm/blob/e5bfb028b9937f8c35a7a98403b900d3b4eab9b9/python/tvm/contrib/cutlass/gen_tensor_op.py#L795 when the model has sliding window, we end up using non-causal attention. This is why Mistral has been broken for short prompts.

I realized that the upstream code sets `params.is_causal` based on the value of `window_size` when the function is called. We also need to do this, to take updated values of `window_size_left` and `window_size_right` into account. Now, the value of `is_causal` passed from a user is only used to set `window_size_right`, similarly to the upstream code https://github.com/Dao-AILab/flash-attention/blob/92dd5703ecdb99aa4a4aee9817f28557907403a2/csrc/flash_attn/flash_api.cpp#L300   